### PR TITLE
Drop node-8 support, replace by node-14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,10 @@ jobs:
           command: |
             ./cc-test-reporter sum-coverage --output - --parts $CIRCLE_NODE_TOTAL coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
 
-  node-8:
+  node-14:
     <<: *test
     docker:
-      - image: node:8
+      - image: node:14
   cache:
     <<: *test
     steps:
@@ -62,7 +62,7 @@ workflows:
   'vue-preferences':
     jobs:
       - node-10
-      - node-8
+      - node-14
       - cache:
           filters:
             tags:


### PR DESCRIPTION
https://nodejs.org/en/about/releases/

![image](https://user-images.githubusercontent.com/11605133/107857311-841ba800-6e0c-11eb-99be-0ce76bb73130.png)
